### PR TITLE
fixed RED predict_reward error/bug.

### DIFF
--- a/models.py
+++ b/models.py
@@ -202,4 +202,4 @@ class REDDiscriminator(nn.Module):
 
   def predict_reward(self, state, action):
     prediction, target = self.forward(state, action)
-    return torch.exp(-self.sigma_1 * (prediction - target).pow(2).mean(axis=1))
+    return torch.exp(-self.sigma_1 * (prediction - target).pow(2).mean(dim=1))

--- a/models.py
+++ b/models.py
@@ -202,4 +202,4 @@ class REDDiscriminator(nn.Module):
 
   def predict_reward(self, state, action):
     prediction, target = self.forward(state, action)
-    return _gaussian_kernel(prediction, target, gamma=self.sigma_1).mean(dim=1)
+    return torch.exp(-self.sigma_1 * (target-prediction).pow(2).mean(axis=1))

--- a/models.py
+++ b/models.py
@@ -202,4 +202,4 @@ class REDDiscriminator(nn.Module):
 
   def predict_reward(self, state, action):
     prediction, target = self.forward(state, action)
-    return torch.exp(-self.sigma_1 * (target-prediction).pow(2).mean(axis=1))
+    return torch.exp(-self.sigma_1 * (prediction - target).pow(2).mean(axis=1))


### PR DESCRIPTION
 Before: took the square distance between One [state,action] pair and ALL other pairs in the batch (for every [state, action] pair),  see `_square_distance(x,y)` function in `models.py`, which is used in `_gaussian_kernel` function. But the predicted reward is supposed to be the square distance between output of two different NN (Predictor vs Target network) with input:[state, action].

See original RED implementation: https://github.com/RuohanW/RED/blob/412aba4e9fc68102b14040e5fa0989cc3ab9aaa3/baselines/rnd_gail/rnd_critic.py#L29 for reference